### PR TITLE
Engine properties are disabled if no engine is selected

### DIFF
--- a/abstractmodels.cpp
+++ b/abstractmodels.cpp
@@ -302,6 +302,12 @@ void EngineListModel::setDoomExe()
     QString title = tr("Find your original iD Engine executable (e.g. DOOM2.EXE)");
     QString filter = tr("EXE Files (*.EXE);;All files (*)");
     QString tempPath = QFileDialog::getOpenFileName(NULL, title, "", filter);
+
+    if (tempPath == NULL)
+    {
+        return;
+    }
+
     QFileInfo doomfile(tempPath);
 
     if (!doomfile.exists())

--- a/enginesetup.cpp
+++ b/enginesetup.cpp
@@ -56,6 +56,7 @@ void RocketLauncher2::on_button_removeEng_clicked()
 
 void RocketLauncher2::on_listbox_engines_clicked(const QModelIndex &index)
 {
+    ui->groupBox_4->setEnabled(true);
     ui->input_selEngName->setText(
                 enginelist->data(index,Qt::DisplayRole).toString()
                 );

--- a/rocketlauncher2.ui
+++ b/rocketlauncher2.ui
@@ -871,6 +871,9 @@ External File</string>
         </item>
         <item row="0" column="2" alignment="Qt::AlignVCenter">
          <widget class="QGroupBox" name="groupBox_4">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
           <property name="title">
            <string>Engine Properties</string>
           </property>


### PR DESCRIPTION
This resolve the #9 segfault.

Also properly handles "Cancel" on the dialog box used to browse for the iD DOS executable.