### PR TITLE
Properly set the GZdoom logo as engine picture

### DIFF
--- a/enginesetup.cpp
+++ b/enginesetup.cpp
@@ -184,7 +184,7 @@ void RocketLauncher2::on_combo_EngPic_currentTextChanged(const QString &arg1)
         enginelist->setPicFromIndex(Pic_Edge, index);
     else if (arg1 == "Eternity")
         enginelist->setPicFromIndex(Pic_Eternity, index);
-    else if (arg1 == "GZDoom")
+    else if (arg1 == "GZdoom")
         enginelist->setPicFromIndex(Pic_GZdoom, index);
     else if (arg1 == "Legacy")
         enginelist->setPicFromIndex(Pic_Legacy, index);


### PR DESCRIPTION
Fixes #22.

It was a simple typo in the code.